### PR TITLE
Hash private RFQ fields

### DIFF
--- a/lib/src/protocol/crypto.dart
+++ b/lib/src/protocol/crypto.dart
@@ -1,0 +1,20 @@
+import 'dart:convert';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:web5/web5.dart';
+
+class CryptoUtils {
+  static Uint8List digest(Object value) {
+    final payload = json.encode(value);
+    final bytes = utf8.encode(payload);
+    return Uint8List.fromList(sha256.convert(bytes).bytes);
+  }
+
+  static String generateSalt() {
+    var random = Random.secure();
+    var bytes = Uint8List.fromList(List.generate(16, (_) => random.nextInt(256)));
+    return Base64Url.encode(bytes);
+  }
+}

--- a/lib/src/protocol/exceptions.dart
+++ b/lib/src/protocol/exceptions.dart
@@ -1,8 +1,8 @@
 // Tbdex exception codes are each thrown in exactly one place.
 // Each code is prefixed with the name of the file in which it is thrown.
 enum TbdexExceptionCode {
-  parserJsonNull,
   parserKindRequired,
+  parserMessageJsonNotObject,
   parserMetadataMalformed,
   parserUnknownMessageKind,
   parserUnknownResourceKind,

--- a/lib/src/protocol/exceptions.dart
+++ b/lib/src/protocol/exceptions.dart
@@ -3,7 +3,6 @@
 enum TbdexExceptionCode {
   parserJsonNull,
   parserKindRequired,
-  parserInvalidJson,
   parserMetadataMalformed,
   parserUnknownMessageKind,
   parserUnknownResourceKind,

--- a/lib/src/protocol/exceptions.dart
+++ b/lib/src/protocol/exceptions.dart
@@ -1,0 +1,61 @@
+// Tbdex exception codes are each thrown in exactly one place.
+// Each code is prefixed with the name of the file in which it is thrown.
+enum TbdexExceptionCode {
+  parserKindRequired,
+  parserInvalidJson,
+  parserMetadataRequired,
+  parserUnknownMessageKind,
+  parserUnknownResourceKind,
+  messageSignatureMissing,
+  messageSignatureMismatch,
+  messageUnknownKind,
+  resourceSignatureMissing,
+  resourceSignatureMismatch,
+  resourceUnknownKind,
+  rfqClaimsHashMismatch,
+  rfqClaimsMissing,
+  rfqOfferingIdMismatch,
+  rfqPrivateDataMissing,
+  rfqPayinDetailsHashMismatch,
+  rfqPayinDetailsMissing,
+  rfqPayinGreaterThanMax,
+  rfqPayinLessThanMin,
+  rfqPayinDetailsNotValid,
+  rfqPayoutDetailsHashMismatch,
+  rfqPayoutDetailsMissing,
+  rfqPayoutDetailsNotValid,
+  rfqProtocolVersionMismatch,
+  rfqUnknownPayinKind,
+  rfqUnknownPayoutKind,
+  validatorNoSchema,
+  validatorUnknownMessageKind,
+  validatorUnknownResourceKind,
+  validatorJsonSchemaError,
+}
+
+// TbdexException is the parent class for all custom exceptions thrown from this package
+class TbdexException implements Exception {
+  final String message;
+  final TbdexExceptionCode code;
+  TbdexException(this.code, this.message);
+
+  @override
+  String toString() => 'TbdexException($code): $message';
+}
+
+class TbdexParseException extends TbdexException {
+  TbdexParseException(TbdexExceptionCode code, String message): super(code, message);
+}
+
+class TbdexSignatureVerificationException extends TbdexException {
+  TbdexSignatureVerificationException(TbdexExceptionCode code, String message): super(code, message);
+}
+
+class TbdexValidatorException extends TbdexException {
+  TbdexValidatorException(TbdexExceptionCode code, String message): super(code, message);
+}
+
+// Thrown when verifying RFQ against offering
+class TbdexVerifyOfferingRequirementsException extends TbdexException {
+  TbdexVerifyOfferingRequirementsException(TbdexExceptionCode code, String message): super(code, message);
+}

--- a/lib/src/protocol/exceptions.dart
+++ b/lib/src/protocol/exceptions.dart
@@ -1,6 +1,7 @@
 // Tbdex exception codes are each thrown in exactly one place.
 // Each code is prefixed with the name of the file in which it is thrown.
 enum TbdexExceptionCode {
+  parserJsonNull,
   parserKindRequired,
   parserInvalidJson,
   parserMetadataRequired,

--- a/lib/src/protocol/json-schemas/message.schema.json
+++ b/lib/src/protocol/json-schemas/message.schema.json
@@ -41,10 +41,6 @@
         }
       },
       "required": ["from", "to", "kind", "id", "exchangeId", "createdAt", "protocol"]
-    },
-    "Private": {
-      "type": "object",
-      "description": "An ephemeral JSON object used to transmit sensitive data (e.g. PII)"
     }
   },
   "type": "object",
@@ -60,8 +56,9 @@
       "type": "string",
       "description": "Signature that verifies the authenticity and integrity of a message"
     },
-    "private": {
-      "$ref": "#/definitions/Private"
+    "privateData": {
+      "type": "object",
+      "description": "Private data which can be detached from the payload without disrupting integrity. Only used in RFQs"
     }
   },
   "additionalProperties": false,

--- a/lib/src/protocol/json-schemas/rfq-private.schema.json
+++ b/lib/src/protocol/json-schemas/rfq-private.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://tbdex.dev/rfq-private.schema.json",
+  "type": "object",
+  "properties": {
+    "additionalProperties": false,
+    "salt": {
+      "type": "string",
+      "description": "Randomly generated cryptographic salt used to hash privateData fields"
+    },
+    "claims": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Presentation Submission that fulfills the requirements included in the respective Offering"
+    },
+    "payin": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "paymentDetails": {
+          "type": "object",
+          "description": "An object containing the properties defined in the respective Offering's requiredPaymentDetails json schema"
+        }
+      }
+    },
+    "payout": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "paymentDetails": {
+          "type": "object",
+          "description": "An object containing the properties defined in the respective Offering's requiredPaymentDetails json schema"
+        }
+      }
+    }
+  },
+  "required": ["salt"]
+}

--- a/lib/src/protocol/json-schemas/rfq.schema.json
+++ b/lib/src/protocol/json-schemas/rfq.schema.json
@@ -8,12 +8,9 @@
       "type": "string",
       "description": "Offering which Alice would like to get a quote for"
     },
-    "claims": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      },
-      "description": "Presentation Submission that fulfills the requirements included in the respective Offering"
+    "claimsHash": {
+      "type": "string",
+      "description": "Digests of Presentation Submissions that fulfills the requirements included in the respective Offering"
     },
     "payin": {
       "type": "object",
@@ -25,9 +22,9 @@
           "type": "string",
           "description": "Type of payment method e.g. BTC_ADDRESS, DEBIT_CARD, MOMO_MPESA"
         },
-        "paymentDetails": {
-          "type": "object",
-          "description": "An object containing the properties defined in the respective Offering's requiredPaymentDetails json schema"
+        "paymentDetailsHash": {
+          "type": "string",
+          "description": "Digest of an object containing the properties defined in the respective Offering's requiredPaymentDetails json schema"
         }
       },
       "required": ["amount", "kind"]
@@ -39,13 +36,13 @@
           "type": "string",
           "description": "Selected payout method from the respective offering"
         },
-        "paymentDetails": {
-          "type": "object",
-          "description": "An object containing the properties defined in the respective Offering's requiredPaymentDetails json schema"
+        "paymentDetailsHash": {
+          "type": "string",
+          "description": "Digest of an object containing the properties defined in the respective Offering's requiredPaymentDetails json schema"
         }
       },
       "required": ["kind"]
     }
   },
-  "required": ["offeringId", "claims", "payin", "payout"]
+  "required": ["offeringId", "payin", "payout"]
 }

--- a/lib/src/protocol/models/message_data.dart
+++ b/lib/src/protocol/models/message_data.dart
@@ -2,17 +2,100 @@ import 'package:tbdex/src/protocol/models/resource_data.dart';
 
 abstract class MessageData extends Data {}
 
+class PrivatePaymentDetails {
+  final Map<String, dynamic> paymentDetails;
+
+  PrivatePaymentDetails({required this.paymentDetails});
+
+  factory PrivatePaymentDetails.fromJson(Map<String, dynamic> json) {
+    return PrivatePaymentDetails(
+      paymentDetails: json['paymentDetails'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'paymentDetails': paymentDetails,
+    };
+  }
+}
+
+class RfqPrivateData {
+  final String salt;
+  final PrivatePaymentDetails? payin;
+  final PrivatePaymentDetails? payout;
+  final List<String>? claims;
+
+  RfqPrivateData({required this.salt, this.payin, this.payout, this.claims});
+
+  factory RfqPrivateData.fromJson(Map<String, dynamic> json) {
+    return RfqPrivateData(
+      salt: json['salt'],
+      payin: json['payin'] != null ? PrivatePaymentDetails.fromJson(json['payin']) : null,
+      payout: json['payout'] != null ? PrivatePaymentDetails.fromJson(json['payout']) : null,
+      claims: json['claims'] != null ?
+        (json['claims'] as List).map((claim) => claim as String).toList() :
+        null,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'salt': salt,
+      if (payin != null) 'payin': payin!.toJson(),
+      if (payout != null) 'payout': payout!.toJson(),
+      if (claims != null) 'claims': claims,
+    };
+  }
+}
+
+class CreateSelectedPayinMethod {
+  final String amount;
+  final String kind;
+  final Map<String, dynamic>? paymentDetails;
+
+  CreateSelectedPayinMethod({
+    required this.amount,
+    required this.kind,
+    this.paymentDetails,
+  });
+}
+
+class CreateSelectedPayoutMethod {
+  final String kind;
+  final Map<String, dynamic>? paymentDetails;
+
+  CreateSelectedPayoutMethod({
+    required this.kind,
+    this.paymentDetails,
+  });
+}
+
+class CreateRfqData {
+  final String offeringId;
+  final CreateSelectedPayinMethod payin;
+  final CreateSelectedPayoutMethod payout;
+  final List<String>? claims;
+
+  CreateRfqData({
+    required this.offeringId,
+    required this.payin,
+    required this.payout,
+    this.claims,
+  });
+}
+
 class RfqData extends MessageData {
   final String offeringId;
   final SelectedPayinMethod payin;
   final SelectedPayoutMethod payout;
-  final List<String> claims;
+  final String? claimsHash;
 
   RfqData({
     required this.offeringId,
     required this.payin,
     required this.payout,
-    required this.claims,
+    required this.claimsHash,
   });
 
   factory RfqData.fromJson(Map<String, dynamic> json) {
@@ -20,7 +103,7 @@ class RfqData extends MessageData {
       offeringId: json['offeringId'],
       payin: SelectedPayinMethod.fromJson(json['payin']),
       payout: SelectedPayoutMethod.fromJson(json['payout']),
-      claims: (json['claims'] as List).map((claim) => claim as String).toList(),
+      claimsHash: json['claimsHash'],
     );
   }
 
@@ -29,7 +112,7 @@ class RfqData extends MessageData {
       'offeringId': offeringId,
       'payin': payin.toJson(),
       'payout': payout.toJson(),
-      'claims': claims,
+      if (claimsHash != null) 'claimsHash': claimsHash,
     };
   }
 }
@@ -37,19 +120,19 @@ class RfqData extends MessageData {
 class SelectedPayinMethod {
   final String amount;
   final String kind;
-  final Map<String, dynamic>? paymentDetails;
+  final String? paymentDetailsHash;
 
   SelectedPayinMethod({
     required this.amount,
     required this.kind,
-    this.paymentDetails,
+    this.paymentDetailsHash,
   });
 
   factory SelectedPayinMethod.fromJson(Map<String, dynamic> json) {
     return SelectedPayinMethod(
       amount: json['amount'],
       kind: json['kind'],
-      paymentDetails: json['paymentDetails'],
+      paymentDetailsHash: json['paymentDetailsHash'],
     );
   }
 
@@ -57,28 +140,28 @@ class SelectedPayinMethod {
     return {
       'amount': amount,
       'kind': kind,
-      if (paymentDetails != null) 'paymentDetails': paymentDetails,
+      if (paymentDetailsHash != null) 'paymentDetailsHash': paymentDetailsHash,
     };
   }
 }
 
 class SelectedPayoutMethod {
   final String kind;
-  final Map<String, dynamic>? paymentDetails;
+  final String? paymentDetailsHash;
 
-  SelectedPayoutMethod({required this.kind, this.paymentDetails});
+  SelectedPayoutMethod({required this.kind, this.paymentDetailsHash});
 
   factory SelectedPayoutMethod.fromJson(Map<String, dynamic> json) {
     return SelectedPayoutMethod(
       kind: json['kind'],
-      paymentDetails: json['paymentDetails'],
+      paymentDetailsHash: json['paymentDetailsHash'],
     );
   }
 
   Map<String, dynamic> toJson() {
     return {
       'kind': kind,
-      if (paymentDetails != null) 'paymentDetails': paymentDetails,
+      if (paymentDetailsHash != null) 'paymentDetailsHash': paymentDetailsHash,
     };
   }
 }

--- a/lib/src/protocol/models/resource.dart
+++ b/lib/src/protocol/models/resource.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:crypto/crypto.dart';
+import 'package:tbdex/src/protocol/exceptions.dart';
 import 'package:tbdex/src/protocol/models/resource_data.dart';
 import 'package:tbdex/src/protocol/validator.dart';
 import 'package:typeid/typeid.dart';
@@ -36,7 +37,7 @@ class ResourceMetadata extends Metadata {
     return ResourceMetadata(
       kind: ResourceKind.values.firstWhere(
         (kind) => kind.name == json['kind'],
-        orElse: () => throw Exception('unknown resource kind: ${json['kind']}'),
+        orElse: () => throw TbdexParseException(TbdexExceptionCode.resourceUnknownKind, 'unknown resource kind: ${json['kind']}'),
       ),
       from: json['from'],
       id: json['id'],
@@ -81,7 +82,8 @@ abstract class Resource {
 
   Future<void> verify() async {
     if (signature == null) {
-      throw Exception(
+      throw TbdexSignatureVerificationException(
+        TbdexExceptionCode.resourceSignatureMissing,
         'signature verification failed: expected signature property to exist',
       );
     }
@@ -92,7 +94,8 @@ abstract class Resource {
     final signingDid = parsedDidUrl.uri;
 
     if (signingDid != metadata.from) {
-      throw Exception(
+      throw TbdexSignatureVerificationException(
+        TbdexExceptionCode.resourceSignatureMissing,
         'signature verification failed: was not signed by the expected DID',
       );
     }

--- a/lib/src/protocol/models/rfq.dart
+++ b/lib/src/protocol/models/rfq.dart
@@ -1,14 +1,20 @@
+import 'dart:convert';
+
 import 'package:decimal/decimal.dart';
+import 'package:tbdex/src/protocol/crypto.dart';
+import 'package:tbdex/src/protocol/exceptions.dart';
 import 'package:tbdex/src/protocol/models/message.dart';
 import 'package:tbdex/src/protocol/models/message_data.dart';
 import 'package:tbdex/src/protocol/models/offering.dart';
-import 'package:tbdex/src/protocol/parser.dart';
+import 'package:tbdex/src/protocol/validator.dart';
+import 'package:web5/web5.dart';
 
 class Rfq extends Message {
   @override
   final MessageMetadata metadata;
   @override
   final RfqData data;
+  final RfqPrivateData? privateData;
 
   @override
   Set<MessageKind> get validNext => {MessageKind.quote, MessageKind.close};
@@ -16,6 +22,7 @@ class Rfq extends Message {
   Rfq._({
     required this.metadata,
     required this.data,
+    this.privateData,
     String? signature,
   }) : super() {
     this.signature = signature;
@@ -24,7 +31,7 @@ class Rfq extends Message {
   static Rfq create(
     String to,
     String from,
-    RfqData data, {
+    CreateRfqData createRfqData, {
     String? externalId,
     String protocol = '1.0',
   }) {
@@ -41,27 +48,199 @@ class Rfq extends Message {
       externalId: externalId,
     );
 
+    var result = hashPrivateData(createRfqData);
+
     return Rfq._(
       metadata: metadata,
-      data: data,
+      data: result['data'],
+      privateData: result['privateData'],
     );
   }
 
-  static Future<Rfq> parse(String rawMessage) async {
-    final rfq = Parser.parseMessage(rawMessage) as Rfq;
+  static String digestPrivateData(String salt, value) {
+    var digest = CryptoUtils.digest([salt, value]);
+    return Base64Url.encode(digest);
+  }
+
+  static Map<String, dynamic> hashPrivateData(CreateRfqData unhashedRfqData) {
+    var salt = CryptoUtils.generateSalt();
+
+    PrivatePaymentDetails? privatePayin;
+    PrivatePaymentDetails? privatePayout;
+    String? payinDetailsHash;
+    String? payoutDetailsHash;
+    String? claimsHash;
+
+    if (unhashedRfqData.payin.paymentDetails != null) {
+      privatePayin = PrivatePaymentDetails(paymentDetails: unhashedRfqData.payin.paymentDetails!);
+      payinDetailsHash = digestPrivateData(salt, unhashedRfqData.payin.paymentDetails! as Object);
+    }
+
+    if (unhashedRfqData.payout.paymentDetails != null) {
+      privatePayout = PrivatePaymentDetails(paymentDetails: unhashedRfqData.payout.paymentDetails!);
+      payoutDetailsHash = digestPrivateData(salt, unhashedRfqData.payout.paymentDetails! as Object);
+
+    }
+
+    if (unhashedRfqData.claims != null && unhashedRfqData.claims != null) {
+      claimsHash = digestPrivateData(salt, unhashedRfqData.claims);
+    }
+
+    var data = RfqData(
+      offeringId: unhashedRfqData.offeringId,
+      payin: SelectedPayinMethod(
+        amount: unhashedRfqData.payin.amount,
+        kind: unhashedRfqData.payin.kind,
+        paymentDetailsHash: payinDetailsHash,
+      ),
+      payout: SelectedPayoutMethod(
+        kind: unhashedRfqData.payout.kind,
+        paymentDetailsHash: payoutDetailsHash,
+      ),
+      claimsHash: claimsHash,
+    );
+
+
+    var privateData = RfqPrivateData(
+      salt: salt,
+      claims: unhashedRfqData.claims,
+      payin: privatePayin,
+      payout: privatePayout,
+    );
+
+    return {
+      'data': data,
+      'privateData': privateData,
+    };
+  }
+
+  static Future<Rfq> parse(String rawMessage, { requireAllPrivateData = false }) async {
+    final jsonObject = jsonDecode(rawMessage) as Map<String, dynamic>;
+    Validator.validate(jsonObject, 'message');
+    Validator.validate(jsonObject['data'], 'rfq');
+    if (jsonObject['privateData'] != null) {
+      Validator.validate(jsonObject['privateData'], 'rfqPrivate');
+    }
+
+    final rfq = Rfq.fromJson(jsonObject);
     await rfq.verify();
+
+    if (requireAllPrivateData) {
+      rfq.verifyAllPrivateData();
+    } else {
+      rfq.verifyPresentPrivateData();
+    }
+
     return rfq;
+  }
+
+  void verifyAllPrivateData() {
+    if (privateData == null) {
+      throw TbdexParseException(TbdexExceptionCode.rfqPrivateDataMissing, 'Could not verify all privateData because privateData property is missing');
+    }
+
+    // Verify payin details
+    if (data.payin.paymentDetailsHash != null) {
+      verifyPayinDetailsHash();
+    }
+
+    // Verify payout details
+    if (data.payout.paymentDetailsHash != null) {
+      verifyPayoutDetailsHash();
+    }
+
+    // Verify claims
+    if (data.claimsHash != null) {
+      verifyClaimsHash();
+    }
+  }
+
+  void verifyPresentPrivateData() {
+    // Verify payin details
+    if (data.payin.paymentDetailsHash != null && privateData?.payin?.paymentDetails != null) {
+      verifyPayinDetailsHash();
+    }
+
+    // Verify payout details
+    if (data.payout.paymentDetailsHash != null && privateData?.payout?.paymentDetails != null) {
+      verifyPayoutDetailsHash();
+    }
+
+    // Verify claims
+    if (data.claimsHash != null && privateData!.claims != null) {
+      verifyClaimsHash();
+    }
+  }
+
+  void verifyPayinDetailsHash() {
+    if (data.payin.paymentDetailsHash == null) {
+      return;
+    }
+
+    if (privateData?.payin?.paymentDetails == null) {
+      throw TbdexParseException(
+        TbdexExceptionCode.rfqPayinDetailsMissing,
+        'Private data integrity check failed: data.payin.paymentDetailsHash does not match digest of privateData.payin.paymentDetails',
+      );
+    }
+
+    var digest = Rfq.digestPrivateData(privateData!.salt, privateData!.payin!.paymentDetails);
+
+    if (digest != data.payin.paymentDetailsHash) {
+      throw TbdexParseException(TbdexExceptionCode.rfqPayinDetailsHashMismatch, 'Private data integrity check failed: privateData.payin.paymentDetails is missing');
+    }
+  }
+
+  void verifyPayoutDetailsHash() {
+    if (data.payout.paymentDetailsHash == null) {
+      return;
+    }
+
+    if (privateData?.payout?.paymentDetails == null) {
+      throw TbdexParseException(
+        TbdexExceptionCode.rfqPayoutDetailsMissing,
+        'Private data integrity check failed: privateData.payout.paymentDetails is missing',
+      );
+    }
+
+    var digest = Rfq.digestPrivateData(privateData!.salt, privateData!.payout!.paymentDetails);
+
+    if (digest != data.payout.paymentDetailsHash) {
+      throw TbdexParseException(TbdexExceptionCode.rfqPayoutDetailsHashMismatch, 'Private data integrity check failed: data.payout.paymentDetailsHash does not match digest of privateData.payout.paymentDetails');
+    }
+  }
+
+  void verifyClaimsHash() {
+    if (data.claimsHash == null) {
+      return;
+    }
+
+    if (privateData?.claims == null) {
+      throw TbdexParseException(
+        TbdexExceptionCode.rfqClaimsMissing,
+        'Private data integrity check failed: privateData.claims is missing',
+      );
+    }
+
+    var claims = privateData!.claims;
+    var digest = Rfq.digestPrivateData(privateData!.salt, claims);
+
+    if (digest != data.claimsHash) {
+      throw TbdexParseException(TbdexExceptionCode.rfqClaimsHashMismatch, 'Private data integrity check failed: data.claimsHash does not match digest of privateData.claims');
+    }
   }
 
   void verifyOfferingRequirements(Offering offering) {
     if (metadata.protocol != offering.metadata.protocol) {
-      throw Exception(
+      throw TbdexVerifyOfferingRequirementsException(
+        TbdexExceptionCode.rfqProtocolVersionMismatch,
         'protocol version mismatch: ${offering.metadata.protocol} != ${metadata.protocol}',
       );
     }
 
     if (data.offeringId != offering.metadata.id) {
-      throw Exception(
+      throw TbdexVerifyOfferingRequirementsException(
+        TbdexExceptionCode.rfqOfferingIdMismatch,
         'offering id mismatch: ${offering.metadata.id} != ${data.offeringId}',
       );
     }
@@ -69,7 +248,8 @@ class Rfq extends Message {
     if (offering.data.payin.min != null) {
       if (Decimal.parse(data.payin.amount) <
           Decimal.parse(offering.data.payin.min ?? '')) {
-        throw Exception(
+        throw TbdexVerifyOfferingRequirementsException(
+          TbdexExceptionCode.rfqPayinLessThanMin,
           'payin amount is less than the minimum required amount',
         );
       }
@@ -78,7 +258,8 @@ class Rfq extends Message {
     if (offering.data.payin.max != null) {
       if (Decimal.parse(data.payin.amount) >
           Decimal.parse(offering.data.payin.max ?? '')) {
-        throw Exception(
+        throw TbdexVerifyOfferingRequirementsException(
+          TbdexExceptionCode.rfqPayinGreaterThanMax,
           'payin amount is greater than the maximum allowed amount',
         );
       }
@@ -87,23 +268,35 @@ class Rfq extends Message {
     final payinMethod = offering.data.payin.methods.firstWhere(
       (method) => method.kind == data.payin.kind,
       orElse: () =>
-          throw Exception('unknown offering kind: ${data.payin.kind}'),
+          throw TbdexVerifyOfferingRequirementsException(TbdexExceptionCode.rfqUnknownPayinKind, 'unknown payin kind: ${data.payin.kind}'),
     );
 
     final payinSchema = payinMethod.getRequiredPaymentDetailsSchema();
     if (payinSchema != null) {
-      payinSchema.validate(data.payin.paymentDetails);
+      final validationResult = payinSchema.validate(privateData?.payin?.paymentDetails);
+      if (!validationResult.isValid) {
+        throw TbdexVerifyOfferingRequirementsException(
+          TbdexExceptionCode.rfqPayinDetailsNotValid,
+          'Payin details not valid: ${validationResult.errors.join(', ')}',
+        );
+      }
     }
 
     final payoutMethod = offering.data.payout.methods.firstWhere(
       (method) => method.kind == data.payout.kind,
       orElse: () =>
-          throw Exception('unknown offering kind: ${data.payout.kind}'),
+          throw TbdexVerifyOfferingRequirementsException(TbdexExceptionCode.rfqUnknownPayoutKind, 'unknown payout kind: ${data.payout.kind}'),
     );
 
     final payoutSchema = payoutMethod.getRequiredPaymentDetailsSchema();
     if (payoutSchema != null) {
-      payoutSchema.validate(data.payout.paymentDetails);
+      final validationResult = payoutSchema.validate(privateData?.payout?.paymentDetails);
+      if (!validationResult.isValid) {
+        throw TbdexVerifyOfferingRequirementsException(
+          TbdexExceptionCode.rfqPayoutDetailsNotValid,
+          'Payout details not valid: ${validationResult.errors.join(', ')}',
+        );
+      }
     }
 
     // TODO(ethan-tbd): verify claims
@@ -114,6 +307,7 @@ class Rfq extends Message {
     return Rfq._(
       metadata: MessageMetadata.fromJson(json['metadata']),
       data: RfqData.fromJson(json['data']),
+      privateData: json['privateData'] != null ? RfqPrivateData.fromJson(json['privateData']) : null,
       signature: json['signature'],
     );
   }
@@ -122,6 +316,7 @@ class Rfq extends Message {
     return {
       'metadata': metadata.toJson(),
       'data': data.toJson(),
+      if (privateData != null) 'privateData': privateData?.toJson(),
       'signature': signature,
     };
   }

--- a/lib/src/protocol/parser.dart
+++ b/lib/src/protocol/parser.dart
@@ -146,10 +146,7 @@ abstract class Parser {
     }
   }
 
-  static String _getKindFromJson(Map<String, dynamic>? jsonObject) {
-    if (jsonObject == null) {
-      throw TbdexParseException(TbdexExceptionCode.parserInvalidJson, 'string is not a valid json object');
-    }
+  static String _getKindFromJson(Map<String, dynamic> jsonObject) {
     final metadata = jsonObject['metadata'];
 
     if (metadata is! Map<String, dynamic> || metadata.isEmpty) {

--- a/lib/src/protocol/parser.dart
+++ b/lib/src/protocol/parser.dart
@@ -15,7 +15,7 @@ abstract class Parser {
   static Message parseMessage(String rawMessage) {
     final jsonObject = jsonDecode(rawMessage) as Map<String, dynamic>?;
     if (jsonObject == null) {
-      throw Exception('ugh');
+      throw TbdexParseException(TbdexExceptionCode.parserJsonNull, 'Message JSON was null');
     }
     Validator.validate(jsonObject, 'message');
 

--- a/lib/src/protocol/parser.dart
+++ b/lib/src/protocol/parser.dart
@@ -16,14 +16,10 @@ abstract class Parser {
   static Message parseMessage(String rawMessage) {
 
     final jsonObject = jsonDecode(rawMessage) as Map<String, dynamic>?;
-    if (jsonObject == null) {
-      throw TbdexParseException(TbdexExceptionCode.parserJsonNull, 'Message JSON was null');
+    if (jsonObject is! Map<String, dynamic>) {
+      throw TbdexParseException(TbdexExceptionCode.parserMessageJsonNotObject, 'Message JSON must be an object');
     }
     Validator.validate(jsonObject, 'message');
-
-    if (jsonObject is! Map<String, dynamic>) {
-      throw Exception('message must be a json object');
-    }
 
     return _parseMessageJson(jsonObject);
   }

--- a/test/protocol/models/rfq_test.dart
+++ b/test/protocol/models/rfq_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:tbdex/src/protocol/exceptions.dart';
 import 'package:tbdex/src/protocol/models/message.dart';
 import 'package:tbdex/src/protocol/models/message_data.dart';
 import 'package:tbdex/src/protocol/models/resource.dart';
@@ -17,10 +18,10 @@ void main() async {
       final rfq = Rfq.create(
         TestData.pfi,
         TestData.alice,
-        RfqData(
+        CreateRfqData(
           offeringId: TypeId.generate(ResourceKind.offering.name),
-          payin: SelectedPayinMethod(amount: '100', kind: 'BTC_ADDRESS'),
-          payout: SelectedPayoutMethod(kind: 'BANK'),
+          payin: CreateSelectedPayinMethod(amount: '100', kind: 'BTC_ADDRESS'),
+          payout: CreateSelectedPayoutMethod(kind: 'BANK'),
           claims: [],
         ),
         externalId: 'rfq_id',
@@ -41,6 +42,214 @@ void main() async {
 
       expect(parsed, isA<Rfq>());
       expect(parsed.toString(), equals(json));
+    });
+
+    group('.parse', () {
+      group('requireAllPrivateData = true', () {
+        test('succeeds when all privateData is present', () async {
+          final rfq = TestData.getRfq();
+          await rfq.sign(TestData.aliceDid);
+          final json = jsonEncode(rfq.toJson());
+          final parsed = await Rfq.parse(json, requireAllPrivateData: true);
+
+          expect(parsed, isA<Rfq>());
+          expect(parsed.toString(), equals(json));
+        });
+
+        test('throws if private data is missing but hashed fields are present in Rfq.data', () async {
+          final rfq = TestData.getRfq();
+          await rfq.sign(TestData.aliceDid);
+
+          final jsonObject = rfq.toJson();
+          jsonObject.remove('privateData');
+          final json = jsonEncode(jsonObject);
+
+          expect(
+            () async => Rfq.parse(json, requireAllPrivateData: true), 
+            throwsA(predicate((e) => e is TbdexParseException && e.code == TbdexExceptionCode.rfqPrivateDataMissing)),
+          );
+        });
+
+        test('throws if salt is missing but hashed fields are present in Rfq.data', () async {
+          final rfq = TestData.getRfq();
+          await rfq.sign(TestData.aliceDid);
+
+          final jsonObject = rfq.toJson();
+          (jsonObject['privateData']! as Map<String, dynamic>).remove('salt');
+          final json = jsonEncode(jsonObject);
+
+          expect(
+            () async => Rfq.parse(json, requireAllPrivateData: true),
+            throwsA(predicate((e) => e is TbdexValidatorException && e.code == TbdexExceptionCode.validatorJsonSchemaError)),
+          );
+        });
+
+        test('throws if Rfq.privateData.payin.paymentDetails is incorrect but Rfq.data.payin.paymentDetailsHash is present', () async {
+          var rfq = TestData.getRfq();
+
+          var jsonObject = rfq.toJson();
+          // ignore: avoid_dynamic_calls
+          jsonObject['data']['payin']['paymentDetailsHash'] = 'garbage';
+          var rfqWithGarbageHash = Rfq.fromJson(jsonObject);
+          await rfqWithGarbageHash.sign(TestData.aliceDid);
+
+          final json = jsonEncode(rfqWithGarbageHash.toJson());
+
+          expect(
+            () async => Rfq.parse(json, requireAllPrivateData: true),
+            throwsA(predicate((e) => e is TbdexParseException && e.code == TbdexExceptionCode.rfqPayinDetailsHashMismatch)),
+          );
+        });
+
+        test('throws if Rfq.privateData.payout.paymentDetails is incorrect but Rfq.data.payout.paymentDetailsHash is present', () async {
+          var rfq = TestData.getRfq();
+
+          var jsonObject = rfq.toJson();
+          // ignore: avoid_dynamic_calls
+          jsonObject['data']['payout']['paymentDetailsHash'] = 'garbage';
+          var rfqWithGarbageHash = Rfq.fromJson(jsonObject);
+          await rfqWithGarbageHash.sign(TestData.aliceDid);
+
+          final json = jsonEncode(rfqWithGarbageHash.toJson());
+
+          expect(
+            () async => Rfq.parse(json, requireAllPrivateData: true),
+            throwsA(predicate((e) => e is TbdexParseException && e.code == TbdexExceptionCode.rfqPayoutDetailsHashMismatch)),
+          );
+        });
+
+        test('throws if Rfq.privateData.claims is incorrect but Rfq.data.claimsHash is present', () async {
+          var rfq = TestData.getRfq();
+
+          var jsonObject = rfq.toJson();
+          // ignore: avoid_dynamic_calls
+          jsonObject['data']['claimsHash'] = 'garbage';
+          var rfqWithGarbageHash = Rfq.fromJson(jsonObject);
+          await rfqWithGarbageHash.sign(TestData.aliceDid);
+
+          final json = jsonEncode(rfqWithGarbageHash.toJson());
+
+          expect(
+            () async => Rfq.parse(json, requireAllPrivateData: true),
+            throwsA(predicate((e) => e is TbdexParseException && e.code == TbdexExceptionCode.rfqClaimsHashMismatch)),
+          );
+        });
+
+        test('throws if Rfq.privateData.payin.paymentDetails is missing but Rfq.data.payin.paymentDetailsHash is present', () async {
+          var rfq = TestData.getRfq();
+          await rfq.sign(TestData.aliceDid);
+
+          var jsonObject = rfq.toJson();
+          // ignore: avoid_dynamic_calls
+          jsonObject['privateData'].remove('payin');
+
+          final json = jsonEncode(jsonObject);
+
+          expect(
+            () async => Rfq.parse(json, requireAllPrivateData: true),
+            throwsA(predicate((e) => e is TbdexParseException && e.code == TbdexExceptionCode.rfqPayinDetailsMissing)),
+          );
+        });
+
+        test('throws if Rfq.privateData.payout.paymentDetails is missing but Rfq.data.payout.paymentDetailsHash is present', () async {
+          var rfq = TestData.getRfq();
+          await rfq.sign(TestData.aliceDid);
+
+          var jsonObject = rfq.toJson();
+          // ignore: avoid_dynamic_calls
+          jsonObject['privateData'].remove('payout');
+
+          final json = jsonEncode(jsonObject);
+
+          expect(
+            () async => Rfq.parse(json, requireAllPrivateData: true),
+            throwsA(predicate((e) => e is TbdexParseException && e.code == TbdexExceptionCode.rfqPayoutDetailsMissing)),
+          );
+        });
+
+        test('throws if Rfq.privateData.claims is missing but Rfq.data.claimsHash is present', () async {
+          var rfq = TestData.getRfq();
+          await rfq.sign(TestData.aliceDid);
+
+          var jsonObject = rfq.toJson();
+          // ignore: avoid_dynamic_calls
+          jsonObject['privateData'].remove('claims');
+
+          final json = jsonEncode(jsonObject);
+
+          expect(
+            () async => Rfq.parse(json, requireAllPrivateData: true),
+            throwsA(predicate((e) => e is TbdexParseException && e.code == TbdexExceptionCode.rfqClaimsMissing)),
+          );
+        });
+      });
+
+      group('requireAllPrivateData = false', () {
+        test('throws if salt is missing but private fields are present in privateData', () async {
+          final rfq = TestData.getRfq();
+          await rfq.sign(TestData.aliceDid);
+
+          final jsonObject = rfq.toJson();
+          (jsonObject['privateData']! as Map<String, dynamic>).remove('salt');
+          final json = jsonEncode(jsonObject);
+
+          expect(
+            () async => Rfq.parse(json), // requireAllPrivateData = false by default
+            throwsA(predicate((e) => e is TbdexValidatorException && e.code == TbdexExceptionCode.validatorJsonSchemaError)),
+          );
+        });
+
+        test('throws if Rfq.privateData.payin.paymentDetails is incorrect but Rfq.data.payin.paymentDetailsHash is present', () async {
+          var rfq = TestData.getRfq();
+
+          var jsonObject = rfq.toJson();
+          // ignore: avoid_dynamic_calls
+          jsonObject['data']['payin']['paymentDetailsHash'] = 'garbage';
+          var rfqWithGarbageHash = Rfq.fromJson(jsonObject);
+          await rfqWithGarbageHash.sign(TestData.aliceDid);
+
+          final json = jsonEncode(rfqWithGarbageHash.toJson());
+
+          expect(
+            () async => Rfq.parse(json), // requireAllPrivateData = false by default
+            throwsA(predicate((e) => e is TbdexParseException && e.code == TbdexExceptionCode.rfqPayinDetailsHashMismatch)),
+          );
+        });
+
+        test('throws if Rfq.privateData.payout.paymentDetails is incorrect but Rfq.data.payout.paymentDetailsHash is present', () async {
+          var rfq = TestData.getRfq();
+
+          var jsonObject = rfq.toJson();
+          // ignore: avoid_dynamic_calls
+          jsonObject['data']['payout']['paymentDetailsHash'] = 'garbage';
+          var rfqWithGarbageHash = Rfq.fromJson(jsonObject);
+          await rfqWithGarbageHash.sign(TestData.aliceDid);
+
+          final json = jsonEncode(rfqWithGarbageHash.toJson());
+
+          expect(
+            () async => Rfq.parse(json), // requireAllPrivateData = false by default
+            throwsA(predicate((e) => e is TbdexParseException && e.code == TbdexExceptionCode.rfqPayoutDetailsHashMismatch)),
+          );
+        });
+
+        test('throws if Rfq.privateData.claims is incorrect but Rfq.data.claimsHash is present', () async {
+          var rfq = TestData.getRfq();
+
+          var jsonObject = rfq.toJson();
+          // ignore: avoid_dynamic_calls
+          jsonObject['data']['claimsHash'] = 'garbage';
+          var rfqWithGarbageHash = Rfq.fromJson(jsonObject);
+          await rfqWithGarbageHash.sign(TestData.aliceDid);
+
+          final json = jsonEncode(rfqWithGarbageHash.toJson());
+
+          expect(
+            () async => Rfq.parse(json), // requireAllPrivateData = false by default
+            throwsA(predicate((e) => e is TbdexParseException && e.code == TbdexExceptionCode.rfqClaimsHashMismatch)),
+          );
+        });
+      });
     });
 
     test('can verify rfq with offering', () {

--- a/test/protocol/parser_test.dart
+++ b/test/protocol/parser_test.dart
@@ -13,7 +13,9 @@ void main() async {
   group('Parser', () {
     test('can parse a list of messages', () async {
       final rfq = TestData.getRfq();
+      await rfq.sign(TestData.aliceDid);
       final order = TestData.getOrder();
+      await order.sign(TestData.aliceDid);
 
       final messages = await Future.wait(
         [

--- a/test/test_data.dart
+++ b/test/test_data.dart
@@ -69,14 +69,26 @@ class TestData {
     return Rfq.create(
       pfiDid.uri,
       aliceDid.uri,
-      RfqData(
+      CreateRfqData(
         offeringId: offeringId ?? TypeId.generate(ResourceKind.offering.name),
-        payin: SelectedPayinMethod(
+        payin: CreateSelectedPayinMethod(
           amount: amount ?? '100',
           kind: payinKind ?? 'DEBIT_CARD',
+          paymentDetails: Map.of({
+            'cardNumber': '0123456789012345',
+            'expiryDate': '01/21',
+            'cardHolderName': 'John Meme',
+            'cvv': '123',
+          }),
         ),
-        payout: SelectedPayoutMethod(
+        payout: CreateSelectedPayoutMethod(
           kind: payoutKind ?? 'DEBIT_CARD',
+          paymentDetails: Map.of({
+            'cardNumber': '0123456789012345',
+            'expiryDate': '01/21',
+            'cardHolderName': 'John Meme',
+            'cvv': '123',
+          }),
         ),
         claims: [],
       ),


### PR DESCRIPTION
Add `privateData` to RFQ and make exceptions more precise and easier to catch. From the [dart docs for the Exception class](https://api.flutter.dev/flutter/dart-core/Exception-class.html),
> Creating instances of [Exception](https://api.flutter.dev/flutter/dart-core/Exception-class.html) directly with Exception("message") is discouraged in library code since it doesn't give users a precise type they can catch. It may be reasonable to use instances of this class in tests or during development.

The pattern of "error codes" is borrowed from [dwn-sdk-js](https://github.com/tbD54566975/dwn-sdk-js). The pattern of custom error classes -- `TbdexParseException`, `TbdexValidatorException`, etc. -- makes it easier to catch specific exceptions from an action like `.parse()` or `.validate()`.