### PR TITLE
fix: roll back path dep req from `1.9.0` to `1.8.3`

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   http: ^1.2.0
   json_schema: ^5.1.3
   mocktail: ^1.0.3
-  path: ^1.9.0
+  path: ^1.8.3
   typeid: ^1.0.1
   web5:
     git:


### PR DESCRIPTION
resolves compatibility issues as path is pinned to version 1.8.3 by `flutter_test` from the flutter SDK