### PR TITLE
fix: update with web5 changes

### DIFF
--- a/lib/src/http_client/tbdex_http_client.dart
+++ b/lib/src/http_client/tbdex_http_client.dart
@@ -152,7 +152,12 @@ class TbdexHttpClient {
       orElse: () => throw Exception('did does not have service of type PFI'),
     );
 
-    return service?.serviceEndpoint ?? '';
+    final endpoint = service?.serviceEndpoint ?? [];
+
+    if (endpoint.isEmpty) {
+      throw Exception('no service endpoints found');
+    }
+    return 'http://${endpoint[0]}';
   }
 
   static Future<String> _generateRequestToken(

--- a/lib/src/http_client/tbdex_http_client.dart
+++ b/lib/src/http_client/tbdex_http_client.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
+import 'dart:io';
 
-import 'package:http/http.dart' as http;
 import 'package:tbdex/src/http_client/models/create_exchange_request.dart';
 import 'package:tbdex/src/http_client/models/exchange.dart';
 import 'package:tbdex/src/http_client/models/get_offerings_filter.dart';
@@ -19,10 +19,10 @@ class TbdexHttpClient {
   static const _jsonHeader = 'application/json';
   static const _expirationDuration = Duration(minutes: 5);
 
-  static http.Client _client = http.Client();
+  static HttpClient _client = HttpClient();
 
   // ignore: avoid_setters_without_getters
-  static set client(http.Client client) {
+  static set client(HttpClient client) {
     _client = client;
   }
 
@@ -35,18 +35,17 @@ class TbdexHttpClient {
     final pfiServiceEndpoint = await _getPfiServiceEndpoint(pfiDid);
     final url = Uri.parse('$pfiServiceEndpoint/exchanges/$exchangeId');
 
-    final response = await _client.get(
-      url,
-      headers: {
-        'Authorization': 'Bearer $requestToken',
-      },
-    );
+    final request = await _client.getUrl(url);
+    request.headers.set('Authorization', 'Bearer $requestToken');
+    final response = await request.close();
+
+    final body = await response.transform(utf8.decoder).join();
 
     if (response.statusCode != 200) {
-      throw Exception('failed to fetch exchange: ${response.body}');
+      throw Exception('failed to fetch exchange: $body');
     }
 
-    return Parser.parseExchange(response.body);
+    return Parser.parseExchange(body);
   }
 
   static Future<List<Exchange>> getExchanges(
@@ -57,18 +56,17 @@ class TbdexHttpClient {
     final pfiServiceEndpoint = await _getPfiServiceEndpoint(pfiDid);
     final url = Uri.parse('$pfiServiceEndpoint/exchanges/');
 
-    final response = await _client.get(
-      url,
-      headers: {
-        'Authorization': 'Bearer $requestToken',
-      },
-    );
+    final request = await _client.getUrl(url);
+    request.headers.set('Authorization', 'Bearer $requestToken');
+    final response = await request.close();
+
+    final body = await response.transform(utf8.decoder).join();
 
     if (response.statusCode != 200) {
-      throw Exception('failed to fetch exchanges: ${response.body}');
+      throw Exception('failed to fetch exchanges: $body');
     }
 
-    return Parser.parseExchanges(response.body);
+    return Parser.parseExchanges(body);
   }
 
   static Future<List<Offering>> getOfferings(
@@ -80,13 +78,16 @@ class TbdexHttpClient {
       queryParameters: filter?.toJson(),
     );
 
-    final response = await _client.get(url);
+    final request = await _client.getUrl(url);
+    final response = await request.close();
+
+    final body = await response.transform(utf8.decoder).join();
 
     if (response.statusCode != 200) {
       throw Exception(response);
     }
 
-    return Parser.parseOfferings(response.body);
+    return Parser.parseOfferings(body);
   }
 
   static Future<void> createExchange(
@@ -129,11 +130,9 @@ class TbdexHttpClient {
     final path = '/exchanges${exchangeId != null ? '/$exchangeId' : ''}';
     final url = Uri.parse(pfiServiceEndpoint + path);
 
-    final response = await _client.post(
-      url,
-      headers: {'Content-Type': _jsonHeader},
-      body: requestBody,
-    );
+    final request = await _client.postUrl(url);
+    request.headers.set('Content-Type', _jsonHeader);
+    final response = await request.close();
 
     if (response.statusCode != 201) {
       throw Exception(response);

--- a/test/http_client/tbdex_http_client_test.dart
+++ b/test/http_client/tbdex_http_client_test.dart
@@ -8,7 +8,7 @@ import '../test_data.dart';
 class MockClient extends Mock implements http.Client {}
 
 void main() async {
-  const pfiDid = 'did:dht:74hg1efatndi8enx3e4z6c4u8ieh1xfkyay4ntg4dg1w6risu35y';
+  const pfiDid = 'did:web:localhost%3A8892:ingress';
   const pfiServiceEndpoint = 'http://localhost:8892/ingress/pfi';
 
   late MockClient mockHttpClient;


### PR DESCRIPTION
- web5-dart now enforces that a `did:web` service endpoint is a `List<String>`
- adds a temporary fix to a handshake error in `TbdexHttpClient` 