### PR TITLE
fix: mock did resolve in tests

### DIFF
--- a/lib/src/http_client/tbdex_http_client.dart
+++ b/lib/src/http_client/tbdex_http_client.dart
@@ -140,7 +140,8 @@ class TbdexHttpClient {
   }
 
   static Future<String> _getPfiServiceEndpoint(String pfiDid) async {
-    final didResolutionResult = await DidResolver.resolve(pfiDid);
+    final didResolutionResult =
+        await DidResolver.resolve(pfiDid, client: _client);
 
     if (didResolutionResult.didDocument == null) {
       throw Exception('did resolution failed');

--- a/test/http_client/tbdex_http_client_test.dart
+++ b/test/http_client/tbdex_http_client_test.dart
@@ -17,36 +17,55 @@ class MockHttpResponse extends Mock implements HttpClientResponse {}
 
 void main() async {
   const pfiDid = 'did:web:localhost%3A8892:ingress';
+  const didUrl = 'http://localhost:8892/ingress/did.json';
   const pfiServiceEndpoint = 'http://localhost:8892/ingress/pfi';
+
+  const didDoc =
+      '''{"id":"did:web:localhost%3A8892:ingress","verificationMethod":[{"id":"#0","type":"JsonWebKey","controller":"did:web:localhost%3A8892:ingress","publicKeyJwk":{"kty":"OKP","crv":"Ed25519","x":"oQ6Nl6pZjDa0I2MIsPV7q7aXX7moneoIC0XprR6ull8"}}],"service":[{"id":"#pfi","type":"PFI","serviceEndpoint":["localhost:8892/ingress/pfi"]}]}''';
 
   late MockClient client;
   late MockHttpHeaders headers;
-  late MockHttpRequest request;
-  late MockHttpResponse response;
+
+  late MockHttpRequest didRequest;
+  late MockHttpResponse didResponse;
+
+  late MockHttpRequest clientRequest;
+  late MockHttpResponse clientResponse;
+
   await TestData.initializeDids();
 
   group('TbdexHttpClient', () {
     setUp(() {
       client = MockClient();
       headers = MockHttpHeaders();
-      request = MockHttpRequest();
-      response = MockHttpResponse();
+
+      didRequest = MockHttpRequest();
+      didResponse = MockHttpResponse();
+
+      clientRequest = MockHttpRequest();
+      clientResponse = MockHttpResponse();
 
       TbdexHttpClient.client = client;
+
+      when(() => didResponse.statusCode).thenReturn(200);
+      when(() => didResponse.transform(utf8.decoder))
+          .thenAnswer((_) => Stream.value(didDoc));
+      when(() => didRequest.close()).thenAnswer((_) async => didResponse);
+      when(
+        () => client.getUrl(Uri.parse(didUrl)),
+      ).thenAnswer((_) async => didRequest);
     });
 
     test('can get exchange', () async {
-      when(() => request.headers).thenReturn(headers);
-      when(() => request.close()).thenAnswer((_) async => response);
-
-      when(() => response.statusCode).thenReturn(200);
-      when(() => response.transform(utf8.decoder))
+      when(() => clientRequest.headers).thenReturn(headers);
+      when(() => clientResponse.statusCode).thenReturn(200);
+      when(() => clientResponse.transform(utf8.decoder))
           .thenAnswer((_) => Stream.value(TestData.getExchangeResponse()));
-
+      when(() => clientRequest.close()).thenAnswer((_) async => clientResponse);
       when(
         () => client
             .getUrl(Uri.parse('$pfiServiceEndpoint/exchanges/exchange_id')),
-      ).thenAnswer((_) async => request);
+      ).thenAnswer((_) async => clientRequest);
 
       final exchange = await TbdexHttpClient.getExchange(
         TestData.aliceDid,
@@ -63,16 +82,14 @@ void main() async {
     });
 
     test('can get exchanges', () async {
-      when(() => request.headers).thenReturn(headers);
-      when(() => request.close()).thenAnswer((_) async => response);
-
-      when(() => response.statusCode).thenReturn(200);
-      when(() => response.transform(utf8.decoder))
+      when(() => clientRequest.headers).thenReturn(headers);
+      when(() => clientResponse.statusCode).thenReturn(200);
+      when(() => clientResponse.transform(utf8.decoder))
           .thenAnswer((_) => Stream.value(TestData.getExchangesResponse()));
-
+      when(() => clientRequest.close()).thenAnswer((_) async => clientResponse);
       when(
         () => client.getUrl(Uri.parse('$pfiServiceEndpoint/exchanges/')),
-      ).thenAnswer((_) async => request);
+      ).thenAnswer((_) async => clientRequest);
 
       final exchanges = await TbdexHttpClient.getExchanges(
         TestData.aliceDid,
@@ -87,15 +104,13 @@ void main() async {
     });
 
     test('can get offerings', () async {
-      when(() => request.close()).thenAnswer((_) async => response);
-
-      when(() => response.statusCode).thenReturn(200);
-      when(() => response.transform(utf8.decoder))
+      when(() => clientResponse.statusCode).thenReturn(200);
+      when(() => clientResponse.transform(utf8.decoder))
           .thenAnswer((_) => Stream.value(TestData.getOfferingResponse()));
-
+      when(() => clientRequest.close()).thenAnswer((_) async => clientResponse);
       when(
         () => client.getUrl(Uri.parse('$pfiServiceEndpoint/offerings/')),
-      ).thenAnswer((_) async => request);
+      ).thenAnswer((_) async => clientRequest);
 
       final offerings = await TbdexHttpClient.getOfferings(pfiDid);
 
@@ -109,22 +124,18 @@ void main() async {
     test('can create exchange', () async {
       final rfq = TestData.getRfq(to: pfiDid);
       await rfq.sign(TestData.aliceDid);
-      request
+
+      clientRequest
           .write(TestData.getCreateExchangeRequest(rfq, replyTo: 'reply_to'));
-
-      when(() => request.headers).thenReturn(headers);
-      when(() => request.close()).thenAnswer((_) async => response);
-
-      when(() => response.statusCode).thenReturn(201);
-      when(() => response.transform(utf8.decoder)).thenAnswer(
-        (_) => Stream.value(
-          '',
-        ),
+      when(() => clientRequest.headers).thenReturn(headers);
+      when(() => clientResponse.statusCode).thenReturn(201);
+      when(() => clientResponse.transform(utf8.decoder)).thenAnswer(
+        (_) => Stream.value(''),
       );
-
+      when(() => clientRequest.close()).thenAnswer((_) async => clientResponse);
       when(
         () => client.postUrl(Uri.parse('$pfiServiceEndpoint/exchanges')),
-      ).thenAnswer((_) async => request);
+      ).thenAnswer((_) async => clientRequest);
 
       await TbdexHttpClient.createExchange(rfq, replyTo: 'reply_to');
 
@@ -140,20 +151,18 @@ void main() async {
       final exchangeId = order.metadata.exchangeId;
       await order.sign(TestData.aliceDid);
 
-      request.write(TestData.getSubmitOrderRequest(order));
+      clientRequest.write(TestData.getSubmitOrderRequest(order));
 
-      when(() => request.headers).thenReturn(headers);
-      when(() => request.close()).thenAnswer((_) async => response);
-
-      when(() => response.statusCode).thenReturn(201);
-      when(() => response.transform(utf8.decoder)).thenAnswer(
-        (_) => Stream.value(''),
-      );
+      when(() => clientRequest.headers).thenReturn(headers);
+      when(() => clientResponse.statusCode).thenReturn(201);
+      when(() => clientResponse.transform(utf8.decoder))
+          .thenAnswer((_) => Stream.value(''));
+      when(() => clientRequest.close()).thenAnswer((_) async => clientResponse);
 
       when(
         () => client
             .postUrl(Uri.parse('$pfiServiceEndpoint/exchanges/$exchangeId')),
-      ).thenAnswer((_) async => request);
+      ).thenAnswer((_) async => clientRequest);
 
       await TbdexHttpClient.submitOrder(order);
 
@@ -169,20 +178,16 @@ void main() async {
       final exchangeId = close.metadata.exchangeId;
       await close.sign(TestData.aliceDid);
 
-      request.write(TestData.getSubmitCloseRequest(close));
-
-      when(() => request.headers).thenReturn(headers);
-      when(() => request.close()).thenAnswer((_) async => response);
-
-      when(() => response.statusCode).thenReturn(201);
-      when(() => response.transform(utf8.decoder)).thenAnswer(
-        (_) => Stream.value(''),
-      );
-
+      clientRequest.write(TestData.getSubmitCloseRequest(close));
+      when(() => clientRequest.headers).thenReturn(headers);
+      when(() => clientResponse.statusCode).thenReturn(201);
+      when(() => clientResponse.transform(utf8.decoder))
+          .thenAnswer((_) => Stream.value(''));
+      when(() => clientRequest.close()).thenAnswer((_) async => clientResponse);
       when(
         () => client
             .postUrl(Uri.parse('$pfiServiceEndpoint/exchanges/$exchangeId')),
-      ).thenAnswer((_) async => request);
+      ).thenAnswer((_) async => clientRequest);
 
       await TbdexHttpClient.submitClose(close);
 


### PR DESCRIPTION
adds `when()` statements to mock out the http client call that comes from `DidResolver` (bcs of `did:web`) in `TbdexHttpClient`