### PR TITLE
fix: Update `Validator` json schemas

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,6 @@
 schemas:
-  @git submodule update --init --recursive
-  @cp -r tbdex/hosted/json-schemas lib/src/protocol
+  #!/bin/bash
+  dart run generate_schemas.dart
 
 get:
   @dart pub get

--- a/generate_schemas.dart
+++ b/generate_schemas.dart
@@ -1,0 +1,53 @@
+import 'dart:io';
+import 'package:path/path.dart' as p;
+
+void main() {
+  final schemasPath = p.join('tbdex', 'hosted', 'json-schemas');
+  final outputDir = Directory('lib/src/protocol/json-schemas')
+    ..createSync(recursive: true);
+
+  Directory(schemasPath)
+      .listSync()
+      .whereType<File>()
+      .where((file) => file.path.endsWith('.json'))
+      .forEach((file) {
+    final json = file.readAsStringSync();
+    final dartCode = _generateCode(file.path, json);
+
+    File(p.join(outputDir.path, '${_getFileName(file.path)}.dart'))
+        .writeAsStringSync(dartCode);
+  });
+}
+
+String _generateCode(String filePath, String jsonString) => '''
+class ${_getClassName(filePath)} {
+  static const String json = r\'\'\'
+  $jsonString\'\'\';
+}''';
+
+String _getFileName(String filePath) {
+  var segments = p.split(filePath);
+  final index = segments.indexOf('json-schemas');
+  final baseName = segments[index + 1].split('.').first;
+
+  return '${_toSnakeCase(baseName)}_schema';
+}
+
+String _getClassName(String filePath) {
+  var segments = p.split(filePath);
+  final index = segments.indexOf('json-schemas');
+  final baseName = segments[index + 1].split('.').first;
+
+  return '${_toCamelCase(baseName)}Schema';
+}
+
+String _toSnakeCase(String input) => input.replaceAll('-', '_').toLowerCase();
+
+String _toCamelCase(String input) => input
+    .split(RegExp('[_-]'))
+    .map(
+      (str) => str.isEmpty
+          ? ''
+          : str[0].toUpperCase() + str.substring(1).toLowerCase(),
+    )
+    .join();

--- a/lib/src/protocol/json-schemas/balance_schema.dart
+++ b/lib/src/protocol/json-schemas/balance_schema.dart
@@ -1,4 +1,6 @@
-{
+class BalanceSchema {
+  static const String json = r'''
+  {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://tbdex.dev/balance.schema.json",
   "type": "object",
@@ -17,4 +19,6 @@
     "currencyCode",
     "available"
   ]
+}
+''';
 }

--- a/lib/src/protocol/json-schemas/close_schema.dart
+++ b/lib/src/protocol/json-schemas/close_schema.dart
@@ -1,4 +1,6 @@
-{
+class CloseSchema {
+  static const String json = r'''
+  {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://tbdex.dev/close.schema.json",
   "type": "object",
@@ -11,4 +13,5 @@
       "type": "boolean"
     }
   }
+}''';
 }

--- a/lib/src/protocol/json-schemas/definitions_schema.dart
+++ b/lib/src/protocol/json-schemas/definitions_schema.dart
@@ -1,4 +1,6 @@
-{
+class DefinitionsSchema {
+  static const String json = r'''
+  {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://tbdex.dev/definitions.json",
   "type": "object",
@@ -12,4 +14,5 @@
       "pattern": "^([0-9]+(?:[.][0-9]+)?)$"
     }
   }
+}''';
 }

--- a/lib/src/protocol/json-schemas/message_schema.dart
+++ b/lib/src/protocol/json-schemas/message_schema.dart
@@ -1,4 +1,6 @@
-{
+class MessageSchema {
+  static const String json = r'''
+  {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://tbdex.dev/message.schema.json",
   "definitions": {
@@ -63,4 +65,6 @@
   },
   "additionalProperties": false,
   "required": ["metadata", "data", "signature"]
+}
+''';
 }

--- a/lib/src/protocol/json-schemas/offering_schema.dart
+++ b/lib/src/protocol/json-schemas/offering_schema.dart
@@ -1,4 +1,6 @@
-{
+class OfferingSchema {
+  static const String json = r'''
+  {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://tbdex.dev/offering.schema.json",
   "type": "object",
@@ -150,4 +152,6 @@
     "payout",
     "payoutUnitsPerPayinUnit"
   ]
+}
+''';
 }

--- a/lib/src/protocol/json-schemas/order_schema.dart
+++ b/lib/src/protocol/json-schemas/order_schema.dart
@@ -1,7 +1,10 @@
-{
+class OrderSchema {
+  static const String json = r'''
+  {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://tbdex.dev/order.schema.json",
   "type": "object",
   "additionalProperties": false,
   "properties": {}
+}''';
 }

--- a/lib/src/protocol/json-schemas/orderstatus_schema.dart
+++ b/lib/src/protocol/json-schemas/orderstatus_schema.dart
@@ -1,4 +1,6 @@
-{
+class OrderstatusSchema {
+  static const String json = r'''
+  {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://tbdex.dev/orderstatus.schema.json",
   "type": "object",
@@ -11,4 +13,5 @@
       "type":"string"
     }
   }
+}''';
 }

--- a/lib/src/protocol/json-schemas/quote_schema.dart
+++ b/lib/src/protocol/json-schemas/quote_schema.dart
@@ -1,4 +1,6 @@
-{
+class QuoteSchema {
+  static const String json = r'''
+  {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://tbdex.dev/quote.schema.json",
   "definitions": {
@@ -54,4 +56,6 @@
     }
   },
   "required": ["expiresAt", "payin", "payout"]
+}
+''';
 }

--- a/lib/src/protocol/json-schemas/reputation_schema.dart
+++ b/lib/src/protocol/json-schemas/reputation_schema.dart
@@ -1,4 +1,7 @@
-{
+class ReputationSchema {
+  static const String json = r'''
+  {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://tbdex.dev/reputation.schema.json"
+}''';
 }

--- a/lib/src/protocol/json-schemas/resource_schema.dart
+++ b/lib/src/protocol/json-schemas/resource_schema.dart
@@ -1,4 +1,6 @@
-{
+class ResourceSchema {
+  static const String json = r'''
+  {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://tbdex.dev/resource.schema.json",
   "type": "object",
@@ -47,4 +49,6 @@
   },
   "required": ["metadata", "data", "signature"],
   "description": "ResourceModel"
+}
+''';
 }

--- a/lib/src/protocol/json-schemas/rfq_private_schema.dart
+++ b/lib/src/protocol/json-schemas/rfq_private_schema.dart
@@ -1,4 +1,6 @@
-{
+class RfqPrivateSchema {
+  static const String json = r'''
+  {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://tbdex.dev/rfq-private.schema.json",
   "type": "object",
@@ -37,4 +39,6 @@
     }
   },
   "required": ["salt"]
+}
+''';
 }

--- a/lib/src/protocol/json-schemas/rfq_schema.dart
+++ b/lib/src/protocol/json-schemas/rfq_schema.dart
@@ -1,4 +1,6 @@
-{
+class RfqSchema {
+  static const String json = r'''
+  {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://tbdex.dev/rfq.schema.json",
   "type": "object",
@@ -45,4 +47,6 @@
     }
   },
   "required": ["offeringId", "payin", "payout"]
+}
+''';
 }


### PR DESCRIPTION
this pr updates the `just schemas` command to generate json schema dart files which are used in `Validator` (allows for json schemas files to be properly included/read when imported as a dependencies)